### PR TITLE
Add Docker and Docker Compose support for multitor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git specific files
+.git/
+.gitignore
+.gitattributes
+
+# GitHub specific files
+.github/
+
+# Docker specific files (do not ignore Dockerfile itself if it's in the context root)
+# docker-compose.yml # Usually not ignored as it might be used in CI/CD or by users
+# .dockerignore # This file itself
+
+# Documentation files (unless specifically needed in the image)
+README.md
+LICENSE.md
+*.md
+
+# Local development files
+.idea/
+*.swp
+*.swo
+*~
+
+# Custom templates directory - this should be mounted as a volume, not copied
+custom_templates/
+
+# Logs and temporary files (if any are generated locally)
+log/
+tmp/
+
+# OS-specific files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Use alpine as the base image
+FROM alpine:latest
+
+# Environment variables for package versions or configurations
+ENV BUILD_PACKAGES="build-base openssl-dev ca-certificates wget git" \
+    PACKAGES="tor sudo bash haproxy privoxy npm procps netcat"
+
+# Install build and runtime packages
+RUN apk update && \
+    apk add --no-cache $BUILD_PACKAGES $PACKAGES && \
+    npm install -g http-proxy-to-socks && \
+    update-ca-certificates
+
+# Install polipo from source
+RUN wget https://github.com/jech/polipo/archive/master.zip -O polipo.zip && \
+    unzip polipo.zip && \
+    cd polipo-master && \
+    make && \
+    install polipo /usr/local/bin/ && \
+    cd .. && \
+    rm -rf polipo.zip polipo-master && \
+    mkdir -p /usr/share/polipo/www /var/cache/polipo /var/log/polipo
+
+# Clean build packages to reduce image size
+RUN apk del $BUILD_PACKAGES
+
+# Set up application directory
+WORKDIR /usr/src/app
+
+# Copy application files
+COPY . .
+
+# Install multitor
+RUN ./setup.sh install && \
+    # Create log folders required by multitor
+    mkdir -p /var/log/multitor/privoxy/ && \
+    # Modify HAProxy template to listen on all interfaces within the container
+    # Ensure the path to templates/haproxy-template.cfg is correct relative to WORKDIR
+    sed -i 's/127.0.0.1:16379/0.0.0.0:16379/g' templates/haproxy-template.cfg
+
+# Copy the startup script
+COPY startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+
+# Expose the default HAProxy port
+EXPOSE 16379
+
+# Set the entrypoint to the startup script
+CMD ["/usr/local/bin/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,98 @@ Also you will need **root access**.
 
 ## Docker
 
-See this project: **[docker-multitor](https://github.com/evait-security/docker-multitor)**
+This project includes a `Dockerfile` and `docker-compose.yml` for easy setup and deployment.
+
+### Prerequisites
+
+- Docker: [Install Docker](https://docs.docker.com/get-docker/)
+- Docker Compose: [Install Docker Compose](https://docs.docker.com/compose/install/) (usually included with Docker Desktop)
+
+### Building the Docker Image
+
+You can build the Docker image directly using the `docker build` command:
+
+```bash
+docker build -t multitor .
+```
+
+### Running with Docker Compose (Recommended)
+
+The easiest way to run `multitor` with Docker is by using Docker Compose. This method utilizes the `docker-compose.yml` file which is pre-configured for common use cases.
+
+1.  **Start `multitor`**:
+    ```bash
+    docker-compose up
+    ```
+    By default, this will start `multitor` with 5 Tor instances and expose HAProxy on port `16379` of your host machine.
+
+2.  **Customize Tor Instances**:
+    You can change the number of Tor instances by setting the `TOR_INSTANCES` environment variable. You can do this by:
+    *   Creating a `.env` file in the same directory as `docker-compose.yml` with the line:
+        ```
+        TOR_INSTANCES=10
+        ```
+    *   Or by prefixing the command:
+        ```bash
+        TOR_INSTANCES=10 docker-compose up
+        ```
+
+3.  **Using Custom Templates**:
+    If you need to use custom configuration templates for Tor, HAProxy, Privoxy, or Polipo:
+    *   Create a directory named `custom_templates` in the root of the project (same directory as `docker-compose.yml`).
+    *   Place your custom template files in this directory (e.g., `custom_templates/torrc-template.cfg`).
+    *   Docker Compose is configured to mount this directory into the container at `/usr/src/app/templates`. `multitor` will then use any templates it finds there, falling back to its default templates if a custom one isn't provided.
+
+    The default template files that can be overridden are:
+    *   `haproxy-template.cfg`
+    *   `polipo-template.cfg`
+    *   `privoxy-template.cfg`
+    *   `torrc-template.cfg`
+
+4.  **Accessing the Proxy**:
+    Once running, the HAProxy load balancer will be accessible at `http://localhost:16379` (or whatever host your Docker daemon is running on).
+
+5.  **Stopping `multitor`**:
+    ```bash
+    docker-compose down
+    ```
+
+### Running with Docker (Manual)
+
+If you prefer not to use Docker Compose, you can run the container directly using `docker run`.
+
+1.  **Build the image first (if you haven't already)**:
+    ```bash
+    docker build -t multitor .
+    ```
+
+2.  **Run the container**:
+    ```bash
+    docker run -d -p 16379:16379 --name multitor_container -e TOR_INSTANCES=5 multitor
+    ```
+    *   `-d`: Run in detached mode.
+    *   `-p 16379:16379`: Map port 16379.
+    *   `--name multitor_container`: Assign a name to the container.
+    *   `-e TOR_INSTANCES=5`: Set the number of Tor instances.
+    *   To use custom templates, you would need to add a volume mount:
+        ```bash
+        docker run -d -p 16379:16379 --name multitor_container \
+          -e TOR_INSTANCES=5 \
+          -v "$(pwd)/custom_templates:/usr/src/app/templates" \
+          multitor
+        ```
+        Ensure the `custom_templates` directory exists locally.
+
+3.  **Viewing Logs**:
+    ```bash
+    docker logs -f multitor_container
+    ```
+
+4.  **Stopping and Removing the Container**:
+    ```bash
+    docker stop multitor_container
+    docker rm multitor_container
+    ```
 
 ## Other
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  multitor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "16379:16379" # Maps host port 16379 to container port 16379 (HAProxy)
+    volumes:
+      - ./custom_templates:/usr/src/app/templates # Maps custom templates from host to container
+    environment:
+      - TOR_INSTANCES=5 # Default number of Tor instances, can be overridden in .env file or by CLI
+    cap_add:
+      - NET_ADMIN # Required by Tor for some operations, and potentially by HAProxy/Privoxy.
+    # restart: unless-stopped # Optional: configure restart policy

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Default to 5 TOR instances if TOR_INSTANCES is not set or not a number
+DEFAULT_TOR_INSTANCES=5
+TOR_INSTANCE_COUNT="${TOR_INSTANCES:-$DEFAULT_TOR_INSTANCES}"
+
+# Validate that TOR_INSTANCE_COUNT is a number
+if ! [[ "$TOR_INSTANCE_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "Warning: TOR_INSTANCES value ('$TOR_INSTANCES') is not a valid number. Defaulting to $DEFAULT_TOR_INSTANCES instances." >&2
+  TOR_INSTANCE_COUNT=$DEFAULT_TOR_INSTANCES
+fi
+
+echo "Starting multitor with $TOR_INSTANCE_COUNT Tor instances..."
+
+# Execute multitor
+# The user is root because we are in a container.
+# Ports for SOCKS and Control are internal to the container.
+# HAProxy is enabled by default to provide a single entry point.
+# Logs are redirected to /tmp/multitor.log and then tailed to ensure they go to Docker's log output.
+# The --debug and --verbose flags are included for better insight during runtime.
+multitor \
+  --init "$TOR_INSTANCE_COUNT" \
+  --user root \
+  --socks-port 9000 \
+  --control-port 9900 \
+  --proxy privoxy \
+  --haproxy \
+  --verbose \
+  --debug > /tmp/multitor.log 2>&1
+
+# Tail the log file to keep the container running and output logs
+# Using `tail -f` on a file that might not exist immediately can be problematic.
+# Ensure the log file exists before tailing or handle the error.
+if [ ! -f /tmp/multitor.log ]; then
+    touch /tmp/multitor.log
+fi
+tail -f /tmp/multitor.log


### PR DESCRIPTION
This commit introduces Dockerfile and docker-compose.yml to allow users to easily build and run multitor in a containerized environment.

Key features:
- Alpine-based Docker image with all necessary dependencies (Tor, HAProxy, Privoxy, Polipo, hpts).
- Docker Compose configuration for simplified startup and management.
- Ability to customize the number of Tor instances via the TOR_INSTANCES environment variable.
- Support for custom configuration templates by mounting a local `custom_templates` directory.
- Updated README.md with detailed instructions for Docker usage.