### PR TITLE
Refactor Tor health check and use gstatic 204 endpoint

### DIFF
--- a/lib/CheckTorHealth
+++ b/lib/CheckTorHealth
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# shellcheck shell=bash
+
+# ``````````````````````````````````````````````````````````````````````````````
+# Function name: check_tor_instance_health()
+#
+# Description:
+#   Checks if a Tor instance can successfully connect to gstatic.com/generate_204
+#   via its SOCKS proxy and receive an HTTP 204 response.
+#
+# Usage:
+#   check_tor_instance_health SOCKS_PORT
+#
+# Examples:
+#   check_tor_instance_health 9050
+#
+
+function check_tor_instance_health() {
+
+  # shellcheck disable=SC2034
+  local _FUNCTION_ID="check_tor_instance_health"
+  local _STATE=1 # Default to unhealthy
+  local _socks_port="$1"
+
+  # Check if curl is available
+  if ! command -v curl &>/dev/null; then
+    # _logger is not available here as this is a lib file that might be sourced
+    # before _logger is defined. stderr is a safe bet.
+    echo "Error: curl command not found. Cannot check Tor instance health." >&2
+    return 1 # Unhealthy
+  fi
+
+  # Attempt to fetch headers from gstatic.com through the Tor SOCKS proxy
+  # Timeout after 10 seconds if the request hangs.
+  # -s for silent mode (no progress meter)
+  # --head to fetch only headers
+  # -w "%{http_code}" to output only the HTTP status code
+  # http://connectivitycheck.gstatic.com/generate_204 should return 204
+
+  local http_status_code
+  http_status_code=$(timeout 10s curl --socks5-hostname "127.0.0.1:${_socks_port}" \
+    -s --head -w "%{http_code}" \
+    http://connectivitycheck.gstatic.com/generate_204 -o /dev/null)
+
+  local curl_exit_status="$?"
+
+  # Check if curl command was successful AND http status is 204
+  if [[ "$curl_exit_status" -eq 0 ]] && [[ "$http_status_code" -eq 204 ]]; then
+    _STATE=0 # Healthy
+  else
+    # Log failure details if possible (assuming _logger might be available if sourced from main script)
+    # Or simply rely on the exit code for the caller to handle.
+    # For debugging: echo "Health check failed: SOCKS Port=${_socks_port}, Curl Exit=${curl_exit_status}, HTTP Status=${http_status_code}" >&2
+    _STATE=1 # Unhealthy
+  fi
+
+  return $_STATE
+}

--- a/lib/RestartTorInstance
+++ b/lib/RestartTorInstance
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# shellcheck shell=bash
+
+# ``````````````````````````````````````````````````````````````````````````````
+# Function name: restart_tor_instance()
+#
+# Description:
+#   Restarts a specific Tor instance.
+#
+# Usage:
+#   restart_tor_instance "username" "socks_port" "control_port"
+#
+# Examples:
+#   restart_tor_instance "debian-tor" "9050" "9051"
+#
+
+function restart_tor_instance() {
+
+  local _FUNCTION_ID="restart_tor_instance"
+  # shellcheck disable=SC2034
+  local _STATE=0 # Assume success initially
+
+  local _arg_uname="$1"
+  local _arg_socks="$2"
+  local _arg_control="$3"
+
+  # shellcheck disable=SC2154 # _multitor_directory is expected to be global
+  local _proc_dir="${_multitor_directory}/${_arg_socks}"
+  local _pid_file="${_proc_dir}/${_arg_socks}.pid"
+  local _torrc_file="${_proc_dir}/${_arg_socks}.torrc" # Added for completeness, though CreateTorProcess handles it
+
+  _logger "info" \
+    "${_FUNCTION_ID}()" \
+    "Attempting to restart Tor instance with SOCKS port ${_arg_socks}"
+
+  if [[ -f "$_pid_file" ]]; then
+    local _pid
+    _pid=$(cat "${_pid_file}")
+    if [[ -n "$_pid" ]]; then
+      _logger "info" \
+        "${_FUNCTION_ID}()" \
+        "Stopping Tor instance with PID ${_pid} (SOCKS: ${_arg_socks})"
+      DestroyProcess "$_pid" # DestroyProcess is expected to be available
+      # Brief pause to allow the process to terminate and release resources
+      sleep 2
+      # It's good practice to remove the old PID file
+      if rm -f "${_pid_file}"; then
+        _logger "info" \
+          "${_FUNCTION_ID}()" \
+          "Removed old PID file: ${_pid_file}"
+      else
+        _logger "warn" \
+          "${_FUNCTION_ID}()" \
+          "Could not remove old PID file: ${_pid_file}"
+      fi
+    else
+      _logger "warn" \
+        "${_FUNCTION_ID}()" \
+        "PID file ${_pid_file} is empty. Attempting to start new instance anyway."
+    fi
+  else
+    _logger "warn" \
+      "${_FUNCTION_ID}()" \
+      "PID file ${_pid_file} not found. Attempting to start new instance."
+  fi
+
+  _logger "info" \
+    "${_FUNCTION_ID}()" \
+    "Starting new Tor instance for SOCKS port ${_arg_socks}"
+
+  # CreateTorProcess will regenerate the torrc and start Tor
+  # It needs _pass_hash, _multitor_directory, _tml, _logger, _log_stdout to be set globally
+  # It also increments _tor_processes_done or _tor_processes_fail
+  CreateTorProcess "${_arg_uname}" "${_arg_socks}" "${_arg_control}"
+  local _creation_status="$?"
+
+  if [[ "$_creation_status" -eq 0 ]]; then
+    _logger "info" \
+      "${_FUNCTION_ID}()" \
+      "Successfully restarted Tor instance for SOCKS port ${_arg_socks}"
+    return 0
+  else
+    _logger "error" \
+      "${_FUNCTION_ID}()" \
+      "Failed to restart Tor instance for SOCKS port ${_arg_socks}"
+    return 1
+  fi
+}

--- a/src/__init__
+++ b/src/__init__
@@ -107,6 +107,14 @@ function __main__() {
   # Include import file.
   _load "null" "$_import_path"
 
+  # Source our custom library files
+  # Note: CheckConn (for local port checking) is sourced via _load from src/import
+  # shellcheck disable=SC1090,SC1091
+  source "${_lib}/CheckTorHealth"     # For the new internet connectivity health check
+  # shellcheck disable=SC1090,SC1091
+  source "${_lib}/RestartTorInstance" # For restarting Tor instances
+
+
   # Specifies the call parameters of the script, the exact description
   # can be found in _help_ and file README.md.
   local _short_opt="i:ksnu:"
@@ -276,6 +284,9 @@ function __main__() {
   local _pass_gen
   local _pass_gen_ha
   local _pass_hash
+
+  # Array to store configurations of running Tor instances for health monitoring
+  declare -a _running_tor_configs=()
 
   local _num='^[0-9]+$'
 
@@ -576,6 +587,19 @@ function __main__() {
         "socks_port_number: '$socks_port_number', control_port_number: '$control_port_number'"
 
       CreateTorProcess "${user_name}" "${socks_port_number}" "${control_port_number}"
+      local _create_status=$?
+
+      if [[ $_create_status -eq 0 ]]; then
+        # Store the configuration for health monitoring if Tor process started successfully
+        _running_tor_configs+=("${user_name} ${socks_port_number} ${control_port_number}")
+        _logger "info" \
+          "${_FUNCTION_ID}()" \
+          "Stored config for SOCKS ${socks_port_number} for health monitoring."
+      else
+        _logger "warn" \
+          "${_FUNCTION_ID}()" \
+          "Tor process for SOCKS ${socks_port_number} failed to start. Not adding to health monitoring."
+      fi
 
       # For proxy:
       _proxy_ports+=("$socks_port_number")
@@ -1022,6 +1046,77 @@ function __main__() {
   fi
 
   # ````````````````````````````````````````````````````````````````````````````
+
+  # Health monitoring loop
+  # Only run if instances were initialized in this script execution
+  if [[ "$init_state" -eq 1 ]] && [[ "${#_running_tor_configs[@]}" -gt 0 ]]; then
+    _logger "info" \
+      "${_FUNCTION_ID}()" \
+      "Starting Tor instance health monitoring loop."
+
+    while true; do
+      _logger "info" \
+        "${_FUNCTION_ID}()" \
+        "Performing health check for ${#_running_tor_configs[@]} Tor instances."
+
+      local _current_instance_index=0 # Keep track of instance index if needed, though not strictly used in current loop logic
+      for config_str in "${_running_tor_configs[@]}"; do
+        # Read the config string into an array
+        local config_array
+        IFS=' ' read -r -a config_array <<< "$config_str"
+
+        local _cfg_uname="${config_array[0]}"
+        local _cfg_socks_port="${config_array[1]}"
+        local _cfg_control_port="${config_array[2]}"
+
+        _logger "info" \
+          "${_FUNCTION_ID}()" \
+          "Checking health of Tor instance: User=${_cfg_uname}, SOCKS Port=${_cfg_socks_port}, Control Port=${_cfg_control_port}"
+
+        # check_tor_instance_health returns 0 for healthy, 1 for unhealthy
+        if ! check_tor_instance_health "${_cfg_socks_port}"; then
+          _logger "warn" \
+            "${_FUNCTION_ID}()" \
+            "Tor instance on SOCKS port ${_cfg_socks_port} is unhealthy. Attempting restart."
+
+          # Before restarting, we need to ensure _pass_hash is available if CreateTorProcess needs it.
+          # _pass_hash is set globally if init_state is 1.
+          # If it's not set, CreateTorProcess might fail. This implies the monitoring loop
+          # should only realistically run if the main script initialized the Tor instances.
+          # The restart_tor_instance function calls CreateTorProcess which uses the global _pass_hash
+
+          restart_tor_instance "${_cfg_uname}" "${_cfg_socks_port}" "${_cfg_control_port}"
+          local _restart_status=$?
+
+          if [[ $_restart_status -eq 0 ]]; then
+            _logger "info" \
+              "${_FUNCTION_ID}()" \
+              "Successfully submitted restart for Tor instance on SOCKS port ${_cfg_socks_port}."
+            # Note: restart_tor_instance itself calls CreateTorProcess, which might have its own logging.
+            # The _running_tor_configs array remains valid as the restarted instance uses the same config.
+          else
+            _logger "error" \
+              "${_FUNCTION_ID}()" \
+              "Failed to restart Tor instance on SOCKS port ${_cfg_socks_port}."
+          fi
+        else
+          _logger "info" \
+            "${_FUNCTION_ID}()" \
+            "Tor instance on SOCKS port ${_cfg_socks_port} is healthy."
+        fi
+        _current_instance_index=$((_current_instance_index + 1))
+      done
+
+      _logger "info" \
+        "${_FUNCTION_ID}()" \
+        "Health check cycle complete. Waiting for 300 seconds."
+      sleep 300
+    done
+  elif [[ "$init_state" -eq 1 ]] && [[ "${#_running_tor_configs[@]}" -eq 0 ]]; then
+    _logger "warn" \
+      "${_FUNCTION_ID}()" \
+      "Instances were meant to be initialized, but no successful Tor configurations were stored. Monitoring loop will not start."
+  fi
 
   if [[ "$time_tracking" == "true" ]] ; then
 


### PR DESCRIPTION
- Created a new file `lib/CheckTorHealth` for the health check function.
- The `check_tor_instance_health` function now targets `http://connectivitycheck.gstatic.com/generate_204` and verifies the HTTP 204 status for a healthier check.
- Reverted `lib/CheckConn` to its original purpose of local port checking, as it's used by `lib/OutputGen`.
- Updated `src/__init__` to source the new health check file and remove the previous incorrect sourcing.
- The core monitoring and restart logic remains, now utilizing the improved health check.