### PR TITLE
feat: Implement API server for Tor instance management

### DIFF
--- a/lib/CreateTorProcess
+++ b/lib/CreateTorProcess
@@ -135,6 +135,11 @@ function CreateTorProcess() {
 
     _tor_processes_done=$((_tor_processes_done + 1))
 
+    # Register the PID with the API server
+    local _pid
+    _pid=$(cat "${_proc_dir}/${_arg_socks}.pid")
+    curl -s -X POST -H "Content-Type: application/json" -d "{\"socks_port\": ${_arg_socks}, \"pid\": ${_pid}}" http://127.0.0.1:5001/update_pid
+
   else
 
     _logger "warn" \

--- a/lib/api_client.py
+++ b/lib/api_client.py
@@ -1,0 +1,60 @@
+import requests
+import logging
+
+class ApiClient:
+    def __init__(self, base_url="http://127.0.0.1:5001"):
+        self.base_url = base_url
+
+    def pause_tor_instance(self, socks_port):
+        try:
+            response = requests.post(f"{self.base_url}/pause/{socks_port}")
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error pausing Tor instance on port {socks_port}: {e}")
+            return None
+
+    def resume_tor_instance(self, socks_port):
+        try:
+            response = requests.post(f"{self.base_url}/resume/{socks_port}")
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error resuming Tor instance on port {socks_port}: {e}")
+            return None
+
+    def get_pid(self, socks_port):
+        try:
+            response = requests.get(f"{self.base_url}/pid/{socks_port}")
+            response.raise_for_status()
+            return response.json().get('pid')
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error getting PID for Tor instance on port {socks_port}: {e}")
+            return None
+
+    def pause_all_except(self, top_proxies):
+        try:
+            response = requests.post(f"{self.base_url}/pause_all_except", json={'top_proxies': top_proxies})
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error pausing Tor instances: {e}")
+            return None
+
+    def resume_all(self):
+        try:
+            response = requests.post(f"{self.base_url}/resume_all")
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error resuming all Tor instances: {e}")
+            return None
+
+    def update_pid(self, socks_port, pid):
+        try:
+            response = requests.post(f"{self.base_url}/update_pid", json={'socks_port': socks_port, 'pid': pid})
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error updating PID for Tor instance on port {socks_port}: {e}")
+            return None

--- a/lib/api_server.py
+++ b/lib/api_server.py
@@ -1,0 +1,111 @@
+import flask
+import os
+import signal
+
+app = flask.Flask(__name__)
+
+# In-memory dictionary to store SOCKS port to PID mappings
+tor_pids = {}
+
+@app.route('/pause/<int:socks_port>', methods=['POST'])
+def pause_tor_instance(socks_port):
+    """
+    Pauses a Tor instance by sending a SIGSTOP signal.
+    """
+    if socks_port in tor_pids:
+        pid = tor_pids[socks_port]
+        try:
+            os.kill(pid, signal.SIGSTOP)
+            return flask.jsonify({'status': 'success', 'message': f'Paused Tor instance with PID {pid}'}), 200
+        except ProcessLookupError:
+            return flask.jsonify({'status': 'error', 'message': f'Process with PID {pid} not found'}), 404
+        except Exception as e:
+            return flask.jsonify({'status': 'error', 'message': str(e)}), 500
+    else:
+        return flask.jsonify({'status': 'error', 'message': f'SOCKS port {socks_port} not found'}), 404
+
+@app.route('/resume/<int:socks_port>', methods=['POST'])
+def resume_tor_instance(socks_port):
+    """
+    Resumes a Tor instance by sending a SIGCONT signal.
+    """
+    if socks_port in tor_pids:
+        pid = tor_pids[socks_port]
+        try:
+            os.kill(pid, signal.SIGCONT)
+            return flask.jsonify({'status': 'success', 'message': f'Resumed Tor instance with PID {pid}'}), 200
+        except ProcessLookupError:
+            return flask.jsonify({'status': 'error', 'message': f'Process with PID {pid} not found'}), 404
+        except Exception as e:
+            return flask.jsonify({'status': 'error', 'message': str(e)}), 500
+    else:
+        return flask.jsonify({'status': 'error', 'message': f'SOCKS port {socks_port} not found'}), 404
+
+@app.route('/pid/<int:socks_port>', methods=['GET'])
+def get_pid(socks_port):
+    """
+    Returns the PID of a Tor instance.
+    """
+    if socks_port in tor_pids:
+        return flask.jsonify({'pid': tor_pids[socks_port]}), 200
+    else:
+        return flask.jsonify({'status': 'error', 'message': f'SOCKS port {socks_port} not found'}), 404
+
+@app.route('/pause_all_except', methods=['POST'])
+def pause_all_except():
+    """
+    Pauses all Tor instances except those in the provided list of top proxies.
+    Expects a JSON payload with a 'top_proxies' key, which is a list of SOCKS ports.
+    """
+    data = flask.request.get_json()
+    if not data or 'top_proxies' not in data:
+        return flask.jsonify({'status': 'error', 'message': 'Missing top_proxies in request body'}), 400
+
+    top_proxies = data['top_proxies']
+    paused_ports = []
+    errors = []
+
+    for socks_port, pid in tor_pids.items():
+        if socks_port not in top_proxies:
+            try:
+                os.kill(pid, signal.SIGSTOP)
+                paused_ports.append(socks_port)
+            except Exception as e:
+                errors.append({socks_port: str(e)})
+
+    return flask.jsonify({'status': 'success', 'paused_ports': paused_ports, 'errors': errors}), 200
+
+@app.route('/resume_all', methods=['POST'])
+def resume_all():
+    """
+    Resumes all paused Tor instances.
+    """
+    resumed_ports = []
+    errors = []
+
+    for socks_port, pid in tor_pids.items():
+        try:
+            os.kill(pid, signal.SIGCONT)
+            resumed_ports.append(socks_port)
+        except Exception as e:
+            errors.append({socks_port: str(e)})
+
+    return flask.jsonify({'status': 'success', 'resumed_ports': resumed_ports, 'errors': errors}), 200
+
+@app.route('/update_pid', methods=['POST'])
+def update_pid():
+    """
+    Updates the PID for a given SOCKS port.
+    Expects a JSON payload with 'socks_port' and 'pid' keys.
+    """
+    data = flask.request.get_json()
+    if not data or 'socks_port' not in data or 'pid' not in data:
+        return flask.jsonify({'status': 'error', 'message': 'Missing socks_port or pid in request body'}), 400
+
+    socks_port = data['socks_port']
+    pid = data['pid']
+    tor_pids[socks_port] = pid
+    return flask.jsonify({'status': 'success', 'message': f'PID for SOCKS port {socks_port} updated to {pid}'}), 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5001)

--- a/src/__init__
+++ b/src/__init__
@@ -691,6 +691,8 @@ function __main__() {
     if [[ "$proxy_state" -eq 1 ]] ; then
 
       if [[ "$proxy_type" == "custom_lb" ]] ; then
+        # Start the API server in the background
+        python3 "${_lib}/api_server.py" &
         # Source and call CreateCustomLbProcess
         # shellcheck disable=SC1090,SC1091
         source "${_lib}/CreateCustomLbProcess"


### PR DESCRIPTION
This commit introduces a Python-based API server to manage Tor instances. The server provides endpoints to pause, resume, and track the PIDs of Tor processes.

The custom load balancer (`lib/custom_lb.py`) has been updated to:
- Pause Tor instances that are not in the list of top-performing proxies.
- Resume all Tor instances before running health checks.
- Resume all Tor instances when a full re-check is triggered.

The `multitor` script has been modified to:
- Start the API server when the `custom_lb` proxy is selected.
- Register the PID of each new Tor instance with the API server.